### PR TITLE
Update readme, add specify version of pg on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ INSTALL
   cmake ..
   # If postgresql is installed customized, Try cmd as following  
   # cmake -DCMAKE_PREFIX_PATH=/PATH/TO/PGSQL_INSTALL_DIR ..
+  # Ubuntu, To specify version of pg(missing: PostgreSQL_TYPE_INCLUDE_DIR)
+  # cmake -DPostgreSQL_TYPE_INCLUDE_DIR=/usr/include/postgresql/10/server ..
   # In some OS like Ubuntu. Try cmd as following may solve the compiling problem 
   # cmake -DCMAKE_CXX_FLAGS="-Wall -std=c++11" ..
 


### PR DESCRIPTION
Ubuntu 16.04

PostgreSQL 10

```
-- Setting pg_jieba build type - 
CMake Error at /usr/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:108 (message):
  Could NOT find PostgreSQL (missing: PostgreSQL_TYPE_INCLUDE_DIR) (found
  version "10.3 (Ubuntu 10.3-1.pgdg14.04+1)")
Call Stack (most recent call first):
  /usr/share/cmake-2.8/Modules/FindPackageHandleStandardArgs.cmake:315 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-2.8/Modules/FindPostgreSQL.cmake:151 (find_package_handle_standard_args)
  CMakeLists.txt:11 (find_package)
```